### PR TITLE
update indicatif to 0.18, and add windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb2ee6ad319a912210a36e56e3623555817bcc877a7e6e8802d1d69c4d8056"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
  "console",
  "portable-atomic",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.40", features = ["derive"] }
-indicatif = "0.17.12"
+indicatif = "0.18.0"
 memmap2 = "0.9.5"
 zeekstd = { path = "../lib" }
 zstd-safe.workspace = true


### PR DESCRIPTION
title. current version won't compile with given version of indicatif:
```
❯ cargo install --git https://github.com/rorosen/zeekstd.git --bin
    Updating git repository `https://github.com/rorosen/zeekstd.git`
  Installing zeekstd_cli v0.4.0 (https://github.com/rorosen/zeekstd.git#e4ada3ee)
    Updating crates.io index
error: failed to compile `zeekstd_cli v0.4.0 (https://github.com/rorosen/zeekstd.git#e4ada3ee)`, intermediate artifacts can be found at `C:\Users\Lucy\AppData\Local\Temp\cargo-installFpojis`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to select a version for the requirement `indicatif = "^0.17.12"`
    version 0.17.12 is yanked
  location searched: crates.io index
  required by package `zeekstd_cli v0.4.0 (C:\Users\Lucy\.cargo\git\checkouts\zeekstd-3476cb49a2c0167e\e4ada3e\cli)`
```

also added windows support (just wrapping `is_char_device` around a cfg)