### PR TITLE
fuzz: Add a basic round-trip fuzzing, with seeking or not.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -835,6 +851,14 @@ version = "0.6.1"
 dependencies = [
  "proptest",
  "zstd-safe",
+]
+
+[[package]]
+name = "zeekstd-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "zeekstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["cli", "lib"]
+members = ["cli", "lib", "fuzz"]
 
 [workspace.package]
 edition = "2024"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "zeekstd-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.zeekstd]
+path = "../lib"
+
+[[bin]]
+name = "fuzz_roundtrip_basic"
+path = "fuzz_targets/fuzz_roundtrip_basic.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_roundtrip_seek"
+path = "fuzz_targets/fuzz_roundtrip_seek.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_roundtrip_basic.rs
+++ b/fuzz/fuzz_targets/fuzz_roundtrip_basic.rs
@@ -1,0 +1,23 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::{Read, Write};
+use zeekstd::{BytesWrapper, Decoder, EncodeOptions};
+
+fuzz_target!(|data: &[u8]| {
+    let mut compressed: Vec<u8> = Vec::new();
+    {
+        let mut encoder = EncodeOptions::new()
+            .frame_size_policy(zeekstd::FrameSizePolicy::Uncompressed(100))
+            .into_encoder(&mut compressed)
+            .unwrap();
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap();
+    }
+
+    let mut decoder = Decoder::new(BytesWrapper::new(&compressed)).unwrap();
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed).unwrap();
+
+    assert_eq!(data, &decompressed);
+});

--- a/fuzz/fuzz_targets/fuzz_roundtrip_seek.rs
+++ b/fuzz/fuzz_targets/fuzz_roundtrip_seek.rs
@@ -1,0 +1,43 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use std::io::{Read, Write};
+use zeekstd::{BytesWrapper, Decoder, EncodeOptions};
+
+fuzz_target!(|data: &[u8]| {
+    let (offset0, data) = if let Some(x) = data.split_at_checked(4) {
+        x
+    } else {
+        return;
+    };
+    let offset0 = u32::from_le_bytes(offset0.try_into().unwrap()) as usize;
+    let (offset1, data) = if let Some(x) = data.split_at_checked(4) {
+        x
+    } else {
+        return;
+    };
+    let offset1 = u32::from_le_bytes(offset1.try_into().unwrap()) as usize;
+    if data.is_empty() {
+        return;
+    }
+
+    let mut compressed: Vec<u8> = Vec::new();
+    {
+        let mut encoder = EncodeOptions::new()
+            .frame_size_policy(zeekstd::FrameSizePolicy::Uncompressed(100))
+            .into_encoder(&mut compressed)
+            .unwrap();
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap();
+    }
+
+    for offset in [offset0, offset1] {
+        let offset = offset % data.len();
+        let mut decoder = Decoder::new(BytesWrapper::new(&compressed)).unwrap();
+        decoder.set_offset(offset as u64).unwrap();
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        assert_eq!(&data[offset..], &decompressed);
+    }
+});


### PR DESCRIPTION
I ran into an infinite loop inside zeekstd in decompressing something I'd compressed with it, and I wasn't sure what was going on.  So, I figured it would be a good idea to add some fuzzing to make sure the library is stable.

Basic instructions:

cargo install cargo-fuzz
rustup default nightly
cargo fuzz build
cargo fuzz run fuzz_roundtrip_seek