### PR TITLE
cli: version 0.4.5

### DIFF
--- a/CHANGELOG_CLI.md
+++ b/CHANGELOG_CLI.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.5]
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "zeekstd_cli"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeekstd_cli"
-version = "0.4.4"
+version = "0.4.5"
 description.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
- Do not start printing the progress bar before checking whether output file exists
- Only derive the output file name during decompression when the input file has a `zst` extension
- Refuse reading from stdin, if it is a terminal. Use `--force` to disable the check
- Fix the numbers of frames that are printed when `--num-frames` is passed to the `list` subcommand.
  Formerly this listed one frame too much.
